### PR TITLE
修复iOS平台channel传递的数据类型错误问题

### DIFF
--- a/lib/src/weibo.dart
+++ b/lib/src/weibo.dart
@@ -71,12 +71,12 @@ class Weibo {
   Future<dynamic> _handleMethod(MethodCall call) async {
     switch (call.method) {
       case _METHOD_ONAUTHRESP:
-        _authRespStreamController.add(
-            WeiboAuthResp.fromJson(call.arguments as Map<String, dynamic>));
+        _authRespStreamController.add(WeiboAuthResp.fromJson(
+            (call.arguments as Map<String, dynamic>).cast<String, dynamic>()));
         break;
       case _METHOD_ONSHAREMSGRESP:
-        _shareMsgRespStreamController
-            .add(WeiboSdkResp.fromJson(call.arguments as Map<String, dynamic>));
+        _shareMsgRespStreamController.add(WeiboSdkResp.fromJson(
+            (call.arguments as Map<String, dynamic>).cast<String, dynamic>()));
         break;
     }
   }
@@ -129,7 +129,8 @@ class Weibo {
       if (response.statusCode == HttpStatus.ok) {
         final String content = await utf8.decodeStream(response);
         return WeiboUserInfoResp.fromJson(
-            json.decode(content) as Map<String, dynamic>);
+            (json.decode(content) as Map<String, dynamic>)
+                .cast<String, dynamic>());
       }
       throw HttpException(
           'HttpResponse statusCode: ${response.statusCode}, reasonPhrase: ${response.reasonPhrase}.');

--- a/lib/src/weibo.dart
+++ b/lib/src/weibo.dart
@@ -72,11 +72,11 @@ class Weibo {
     switch (call.method) {
       case _METHOD_ONAUTHRESP:
         _authRespStreamController.add(WeiboAuthResp.fromJson(
-            (call.arguments as Map<String, dynamic>).cast<String, dynamic>()));
+            (call.arguments as Map<dynamic, dynamic>).cast<String, dynamic>()));
         break;
       case _METHOD_ONSHAREMSGRESP:
         _shareMsgRespStreamController.add(WeiboSdkResp.fromJson(
-            (call.arguments as Map<String, dynamic>).cast<String, dynamic>()));
+            (call.arguments as Map<dynamic, dynamic>).cast<String, dynamic>()));
         break;
     }
   }
@@ -129,7 +129,7 @@ class Weibo {
       if (response.statusCode == HttpStatus.ok) {
         final String content = await utf8.decodeStream(response);
         return WeiboUserInfoResp.fromJson(
-            (json.decode(content) as Map<String, dynamic>)
+            (json.decode(content) as Map<dynamic, dynamic>)
                 .cast<String, dynamic>());
       }
       throw HttpException(


### PR DESCRIPTION
`call.arguments`实际类型为`_InternalLinkedHashMap<dynamic, dynamic>`， 使用`as`无法进行转换，会出现报错：`_CastError (type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>' in type cast)`，这里进行修复。